### PR TITLE
Fix memory usage issue caused by adding same node multiple times

### DIFF
--- a/sankey.js
+++ b/sankey.js
@@ -123,7 +123,9 @@ d3.sankey = function(options) {
         node.x = x;
         node.dx = nodeWidth;
         node.sourceLinks.forEach(function(link) {
-          nextNodes.push(link.target);
+          if (nextNodes.indexOf(link.target) == -1) {
+            nextNodes.push(link.target);
+          }
         });
       });
       remainingNodes = nextNodes;


### PR DESCRIPTION
This issue happens when multiple nodes share same target node, and
will consume lots of memory and slow down the layout calculation
greatly when a graph being rendered is close to a complete bipartite
graph at each step of the flow.

This fix was made by @hongtaobai on https://github.com/d3/d3-plugins/commit/65730dc9a5f5441499fca304c1f6f315e3051674#diff-3aa14326cff02f35c6674920e9334c9f.